### PR TITLE
Fix issues with sudoku explanations.

### DIFF
--- a/eprime/sudoku.eprime
+++ b/eprime/sudoku.eprime
@@ -16,7 +16,7 @@ find con_alldiff: matrix indexed by [D,D,D,D] of bool
 $#CON row_alldiff "cells ({a[0]},{a[1]}) and ({a[0]},{a[2]}) cannot both be {a[3]} as they are in the same row"
 find row_alldiff: matrix indexed by [D,D,D,D] of bool
 
-$#CON box_alldiff "cells ({3*int(a[0])+int(a[2])},{3*int(a[1])+int(a[3])}) and ({3*int(a[0])+int(a[4])},{3*int(a[1])+int(a[5])}) cannot both be {a[6]} as they are in the same box"
+$#CON box_alldiff "cells ({3*int(a[0])+int(a[2])+1},{3*int(a[1])+int(a[3])+1}) and ({3*int(a[0])+int(a[4])+1},{3*int(a[1])+int(a[5])+1}) cannot both be {a[6]} as they are in the same box"
 find box_alldiff: matrix indexed by [C,C,C,C,C,C,D] of bool
 
 such that

--- a/eprime/sudoku.eprime
+++ b/eprime/sudoku.eprime
@@ -13,7 +13,7 @@ find grid : matrix indexed by [D,D] of D
 $#CON con_alldiff "cells ({a[0]},{a[1]}) and ({a[0]},{a[2]}) cannot both be {a[3]} as they are in the same column"
 find con_alldiff: matrix indexed by [D,D,D,D] of bool
 
-$#CON row_alldiff "cells ({a[0]},{a[1]}) and ({a[0]},{a[2]}) cannot both be {a[3]} as they are in the same row"
+$#CON row_alldiff "cells ({a[1]},{a[0]}) and ({a[2]},{a[0]}) cannot both be {a[3]} as they are in the same row"
 find row_alldiff: matrix indexed by [D,D,D,D] of bool
 
 $#CON box_alldiff "cells ({3*int(a[0])+int(a[2])+1},{3*int(a[1])+int(a[3])+1}) and ({3*int(a[0])+int(a[4])+1},{3*int(a[1])+int(a[5])+1}) cannot both be {a[6]} as they are in the same box"


### PR DESCRIPTION
The `sudoku.eprime` has some issues leading to weird explanations.

The box constraint indexes from 0, where demystify, and the row and column constraints index from 1. This has been fixed by adding 1 to each coordinate in the eprime file.

The row constraint uses transposed coordinates (col,row instead of row,col). This has also been fixed.

These can both be seen in the image below, taken from [the demystify paper on arxiv](https://arxiv.org/abs/2104.15040).

<img width="1140" alt="sudoku" src="https://github.com/stacs-cp/demystify/assets/9009924/2c7c93b7-1d09-4e53-9768-46ee4d6bd5af">